### PR TITLE
Added option to preserve ':before' and ':after' pseudo elements.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ module.exports = function(options){
             }
 
             // Ignore ':before' and ':after'
-            if (options.perserveBeforeAfter && [':before', ':after'].indexOf(pseudo) !== -1) {
+            if (options.preserveBeforeAfter && [':before', ':after'].indexOf(pseudo) !== -1) {
               return pseudo;
             }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,8 +36,14 @@ module.exports = function(options){
               return pseudo;
             }
 
+            // Ignore ':before' and ':after'
+            if (options.perserveBeforeAfter && [':before', ':after'].indexOf(pseudo) !== -1) {
+              return pseudo;
+            }
+
             // Kill the colon
             pseudo = pseudo.substr(1);
+
 
             // Replace left and right parens
             pseudo = pseudo.replace(/\(/g, '--');


### PR DESCRIPTION
I created this pull request because I had a selector like this:
````
.button:focus:after
`````
which was becoming
````
.button:focus:after,
.button.pseudo-focus.pseudo-after
````
but I wanted
````
.button:focus:after,
.button.pseudo-focus:after
````